### PR TITLE
[fix]:encode/decode app output help

### DIFF
--- a/apps/cwipc_decode/cwipc_decode.cpp
+++ b/apps/cwipc_decode/cwipc_decode.cpp
@@ -5,7 +5,7 @@
 
 int main(int argc, char** argv) {
     if (argc != 3) {
-        std::cerr << "Usage: " << argv[0] << "compressedfile.cwicpc pointcloudfile.ply" << std::endl;
+        std::cerr << "Usage: " << argv[0] << " compressedfile.cwicpc pointcloudfile.ply" << std::endl;
         return 2;
     }
 

--- a/apps/cwipc_encode/cwipc_encode.cpp
+++ b/apps/cwipc_encode/cwipc_encode.cpp
@@ -9,7 +9,7 @@ int main(int argc, char** argv)
     uint64_t timestamp = 0LL;
 
     if (argc < 3 || argc > 6) {
-        std::cerr << "Usage: " << argv[0] << "pointcloudfile.ply compressedfile.cwicpc [timestamp [octree_depth [jpeg_qp]]]" << std::endl;
+        std::cerr << "Usage: " << argv[0] << " pointcloudfile.ply compressedfile.cwicpc [timestamp [octree_depth [jpeg_qp]]]" << std::endl;
         return 2;
     }
 


### PR DESCRIPTION
# cwipc_decode 
Usage: cwipc_decodecompressedfile.cwicpc pointcloudfile.ply
Missing blank space between binary an arguments.
# cwipc_decode 
Usage: cwipc_decode compressedfile.cwicpc pointcloudfile.ply